### PR TITLE
internal client exception

### DIFF
--- a/src/Simplic.OxS.InternalClient/InternalClient.cs
+++ b/src/Simplic.OxS.InternalClient/InternalClient.cs
@@ -83,11 +83,11 @@ namespace Simplic.OxS.InternalClient
 
             if (!result.IsSuccessStatusCode)
             {
-                var error = await GetErrorMessage("GET", endpoint, result);
+                var error = new InternalClientException("GET", endpoint, result);
 
-                logger.LogError(error);
+                logger.LogError(error.Message);
 
-                throw new Exception(error);
+                throw error;
             }
 
             if (result.Content == null)
@@ -122,11 +122,11 @@ namespace Simplic.OxS.InternalClient
 
             if (!result.IsSuccessStatusCode)
             {
-                var error = await GetErrorMessage("POST", endpoint, result);
+                var error = new InternalClientException("POST", endpoint, result);
 
-                logger.LogError(error);
+                logger.LogError(error.Message);
 
-                throw new Exception(error);
+                throw error;
             }
 
             if (result.Content == null)
@@ -161,11 +161,11 @@ namespace Simplic.OxS.InternalClient
 
             if (!result.IsSuccessStatusCode)
             {
-                var error = await GetErrorMessage("PUT", endpoint, result);
+                var error = new InternalClientException("PUT", endpoint, result);
 
-                logger.LogError(error);
+                logger.LogError(error.Message);
 
-                throw new Exception(error);
+                throw error;
             }
 
             if (result.Content == null)
@@ -198,11 +198,11 @@ namespace Simplic.OxS.InternalClient
 
             if (!result.IsSuccessStatusCode)
             {
-                var error = await GetErrorMessage("DELETE", endpoint, result);
+                var error = new InternalClientException("DELETE", endpoint, result);
 
-                logger.LogError(error);
+                logger.LogError(error.Message);
 
-                throw new Exception(error);
+                throw error;
             }
 
             if (result.Content == null)

--- a/src/Simplic.OxS.InternalClient/InternalClient.cs
+++ b/src/Simplic.OxS.InternalClient/InternalClient.cs
@@ -220,17 +220,6 @@ namespace Simplic.OxS.InternalClient
         }
 
         /// <summary>
-        /// Gets a formatted error message
-        /// </summary>
-        /// <param name="method">Http method</param>
-        /// <param name="endpoint">Endpoint query (url)</param>
-        /// <param name="result">Result as string</param>
-        private async Task<string> GetErrorMessage(string method, string endpoint, HttpResponseMessage result)
-        {
-            return $"Internal client error. Endpoint: [{method}] {endpoint} / Status {result.StatusCode} / {await result.Content.ReadAsStringAsync()}";
-        }
-
-        /// <summary>
         /// Convert parameter to query-string
         /// </summary>
         /// <param name="parameter">Parameter as dictionary</param>

--- a/src/Simplic.OxS.InternalClient/InternalClientException.cs
+++ b/src/Simplic.OxS.InternalClient/InternalClientException.cs
@@ -1,0 +1,59 @@
+﻿namespace Simplic.OxS.InternalClient
+{
+    /// <summary>
+    /// Exception thrown when the internal client has an error.
+    /// </summary>
+    public class InternalClientException : Exception
+    {
+        /// <summary>
+        /// Initializes a new Internal Client Exception.
+        /// </summary>
+        /// <param name="method">The method type as string. E.g. "GET"</param>
+        /// <param name="endpoint">The called endpoint.</param>
+        /// <param name="result">The HttpResponseMessage.</param>
+        public InternalClientException(string method, string endpoint, HttpResponseMessage result)
+            :base(GetErrorMessage(method, endpoint, result))
+        {
+            Method = method;
+            Endpoint = endpoint;
+            Result = result;
+        }
+
+        /// <summary>
+        /// Initializes a new Internal Client Exception.
+        /// </summary>
+        /// <param name="method">The method type as string. E.g. "GET"</param>
+        /// <param name="endpoint">The called endpoint.</param>
+        /// <param name="result">The HttpResponseMessage.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public InternalClientException(string method, string endpoint, HttpResponseMessage result, Exception? innerException)
+            : base(GetErrorMessage(method, endpoint, result), innerException)
+        {
+            Method = method;
+            Endpoint = endpoint;
+            Result = result;
+        }
+
+        /// <summary>
+        /// Gets the http method that is called.
+        /// </summary>
+        public string Method { get; }
+
+        /// <summary>
+        /// Gets or the called endpoint.
+        /// </summary>
+        public string Endpoint { get; }
+
+        /// <summary>
+        /// Gets the http response.
+        /// </summary>
+        public HttpResponseMessage Result { get; }
+
+        private static string GetErrorMessage(string method, string endpoint, HttpResponseMessage result)
+        {
+            return $"Internal client error. Endpoint: [{method}] {endpoint} " +
+                $"/ Status {result.StatusCode} " +
+                $"/ {result.Content.ReadAsStringAsync().Result}";
+        }
+    }
+}


### PR DESCRIPTION
I added an internal client exception for a better handling of internal client errors. Since it is currently a bit confusing that an internal server error is thrown when the internal client returned a bad request