### PR TITLE
Set timespan representation

### DIFF
--- a/src/Simplic.OxS.Server/Extensions/GraphQLExtension.cs
+++ b/src/Simplic.OxS.Server/Extensions/GraphQLExtension.cs
@@ -20,6 +20,9 @@ namespace Simplic.OxS.Server.Extensions
                         .AddAuthorization()
                         .AddQueryType<TQuery>();
 
+                        // Set TimeSpan representation to d.hh:mm:ss
+                        req.AddType(new TimeSpanType(TimeSpanFormat.DotNet));
+
             builder?.Invoke(req);
 
             req.AddMongoDbPagingProviders()


### PR DESCRIPTION
Setting the timespan representation to simplic.ox (.net) defaults.

This might be removed from simplic-oxs-logistics, because this implements the same