### PR TITLE
Add functions to update a single property

### DIFF
--- a/src/Simplic.OxS.Data.MongoDB/OrganizationRepository/MongoOrganizationRepositoryBase.cs
+++ b/src/Simplic.OxS.Data.MongoDB/OrganizationRepository/MongoOrganizationRepositoryBase.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using HotChocolate;
 using HotChocolate.Data;
 using MongoDB.Driver;
@@ -138,6 +139,28 @@ namespace Simplic.OxS.Data.MongoDB
         public async Task<IExecutable<TDocument>> GetCollection()
         {
             return context.GetCollection<TDocument>(GetCollectionName()).Find(x => x.OrganizationId == requestContext.OrganizationId).AsExecutable();
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdatePropertyByFilter<TProperty>(
+            TFilter filter,
+            Expression<Func<TDocument, TProperty>> selector,
+            TProperty newValue
+        )
+        {
+            var update = Builders<TDocument>.Update.Set(selector, newValue);
+            await Collection.UpdateManyAsync(BuildFilterQuery(filter), update);
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateProperty<TProperty>(
+            Guid id,
+            Expression<Func<TDocument, TProperty>> selector,
+            TProperty newValue
+        )
+        {
+            var update = Builders<TDocument>.Update.Set(selector, newValue);
+            await Collection.UpdateOneAsync(BuildFilterQuery(new TFilter { Id = id }), update);
         }
     }
 

--- a/src/Simplic.OxS.Data/NoSql/IOrganizationRepository.cs
+++ b/src/Simplic.OxS.Data/NoSql/IOrganizationRepository.cs
@@ -1,4 +1,5 @@
-﻿using HotChocolate;
+﻿using System.Linq.Expressions;
+using HotChocolate;
 
 namespace Simplic.OxS.Data
 {
@@ -25,5 +26,31 @@ namespace Simplic.OxS.Data
         /// </summary>
         /// <returns></returns>
 		Task<IExecutable<TDocument>> GetCollection();
-	}
+
+        /// <summary>
+        /// Updates a property for documents matching the filter.
+        /// </summary>
+        /// <param name="filter">Filter for documents</param>
+        /// <param name="selector">Selects the property that shall be updated</param>
+        /// <param name="newValue">New value to set for that property</param>
+        /// <typeparam name="TProperty">Type of the property</typeparam>
+        Task UpdatePropertyByFilter<TProperty>(
+            TFilter filter,
+            Expression<Func<TDocument, TProperty>> selector,
+            TProperty newValue
+        );
+
+        /// <summary>
+        /// Updates a property for a specific document with given ID.
+        /// </summary>
+        /// <param name="id">ID of the document</param>
+        /// <param name="selector">Selects the property that shall be updated</param>
+        /// <param name="newValue">New value to set for that property</param>
+        /// <typeparam name="TProperty">Type of the property</typeparam>
+        Task UpdateProperty<TProperty>(
+            Guid id,
+            Expression<Func<TDocument, TProperty>> selector,
+            TProperty newValue
+        );
+    }
 }


### PR DESCRIPTION
Adds functions to update a single property for a single document (by ID) as well as multiple documents (by filter).

Use case:
Updating information of documents without overwriting the entire document.
Saves the effort to acquire the whole document when working with pieces of information (performance & comfort).
