### PR TITLE
enable otlp metrics by default

### DIFF
--- a/src/Simplic.OxS.Server/Bootstrap.cs
+++ b/src/Simplic.OxS.Server/Bootstrap.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Simplic.OxS.Data;
 using Simplic.OxS.InternalClient;
 using Simplic.OxS.MessageBroker;
@@ -56,9 +58,9 @@ namespace Simplic.OxS.Server
                 ServiceName = ServiceName,
                 ApiVersion = ApiVersion
             });
-
+            
             // Add logging and tracing systems
-            services.AddLoggingAndMetricTracing(Configuration, ServiceName);
+            services.AddLoggingAndMetricTracing(Configuration, ServiceName, ApiVersion, CurrentEnvironment.EnvironmentName);
 
             // Add Redis caching
             services.AddRedisCaching(Configuration, out string connection);
@@ -150,7 +152,7 @@ namespace Simplic.OxS.Server
                 services.AddSignalR(hubOptions =>
                 {
                     hubOptions.AddFilter<RequestContextHubFilter>();
-                }).AddStackExchangeRedis(connection);
+                }).AddStackExchangeRedis(connection);            
         }
 
         /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry and metrics now include service version and environment name for richer traces and metrics.
  * Instrumentation is environment-aware, enabling context-specific logging and telemetry.
  * Service metadata and an environment attribute are added to exported traces/metrics for better filtering and observability.
  * ASP.NET, HTTP client, and runtime instrumentation with OTLP exporting remain enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->