### PR TITLE
Introduces MakeFieldsNullableTypeInterceptor to prevent null propagation

### DIFF
--- a/src/Simplic.OxS.Server/Extensions/GraphQLExtension.cs
+++ b/src/Simplic.OxS.Server/Extensions/GraphQLExtension.cs
@@ -1,5 +1,6 @@
 ﻿using HotChocolate.Execution.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Simplic.OxS.Server.GraphQL;
 using Simplic.OxS.Server.Middleware;
 
 namespace Simplic.OxS.Server.Extensions
@@ -7,11 +8,21 @@ namespace Simplic.OxS.Server.Extensions
     public static class GraphQLExtension
     {
         /// <summary>
-        /// Enable the use of GraphQL within the simplic eco system 
+        /// Enable the use of GraphQL within the simplic eco system.
         /// </summary>
-        /// <param name="services"></param>
-        /// <returns></returns>
-        public static IServiceCollection UseGraphQL<TQuery>(this IServiceCollection services, Action<IRequestExecutorBuilder> builder = null) where TQuery : class
+        /// <param name="services">DI service collection.</param>
+        /// <param name="builder">Optional builder hook for service-specific extensions.</param>
+        /// <param name="tolerateMissingFieldValues">
+        /// When <c>true</c> (default), every output field on user-defined object types is
+        /// made nullable in the generated schema. This prevents <c>NonNull</c> spec
+        /// violations when a resolver returns <c>null</c> for a property that wasn't
+        /// stored on legacy documents. Set to <c>false</c> for strict, spec-conformant
+        /// non-null behavior (clients then must handle the propagated <c>null</c>).
+        /// </param>
+        public static IServiceCollection UseGraphQL<TQuery>(
+            this IServiceCollection services,
+            Action<IRequestExecutorBuilder> builder = null,
+            bool tolerateMissingFieldValues = true) where TQuery : class
         {
             var req = services.AddGraphQLServer().ModifyOptions(o =>
             {
@@ -21,6 +32,9 @@ namespace Simplic.OxS.Server.Extensions
             .AddHttpRequestInterceptor<HttpRequestInterceptor>()
             .AddAuthorization()
             .AddQueryType<TQuery>();
+
+            if (tolerateMissingFieldValues)
+                req.TryAddTypeInterceptor<MakeFieldsNullableTypeInterceptor>();
 
             // Set TimeSpan representation to d.hh:mm:ss
             req.AddType(new TimeSpanType(TimeSpanFormat.DotNet));

--- a/src/Simplic.OxS.Server/GraphQL/MakeFieldsNullableTypeInterceptor.cs
+++ b/src/Simplic.OxS.Server/GraphQL/MakeFieldsNullableTypeInterceptor.cs
@@ -1,0 +1,56 @@
+using HotChocolate.Configuration;
+using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Configurations;
+
+namespace Simplic.OxS.Server.GraphQL
+{
+    /// <summary>
+    /// HotChocolate type interceptor that rewrites every output field of every
+    /// user-defined object type so its outermost type becomes nullable.
+    /// <para>
+    /// Purpose: tolerate items that are missing values for fields the schema
+    /// would otherwise mark as <c>NonNull</c>. Without this interceptor, a
+    /// resolver returning <c>null</c> for a <c>!</c>-field causes the parent
+    /// selection-set to be replaced by <c>null</c> (per GraphQL spec).
+    /// </para>
+    /// <para>
+    /// HotChocolate built-in types (introspection, paging connections, etc.)
+    /// are skipped because clients depend on their non-null guarantees.
+    /// </para>
+    /// </summary>
+    internal sealed class MakeFieldsNullableTypeInterceptor : TypeInterceptor
+    {
+        public override void OnBeforeCompleteName(
+            ITypeCompletionContext completionContext,
+            TypeSystemConfiguration configuration)
+        {
+            if (completionContext.IsIntrospectionType)
+                return;
+
+            if (configuration is not ObjectTypeConfiguration objectConfig)
+                return;
+
+            // Skip HotChocolate's own types (Connection, Edge, PageInfo, ...).
+            var runtimeType = objectConfig.RuntimeType;
+            if (runtimeType?.Namespace is { } ns &&
+                ns.StartsWith("HotChocolate", System.StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            foreach (var field in objectConfig.Fields)
+            {
+                if (field.IsIntrospectionField)
+                    continue;
+
+                if (field.Type is not ExtendedTypeReference extRef)
+                    continue;
+
+                var nullableType = completionContext.TypeInspector
+                    .ChangeNullability(extRef.Type, true);
+
+                field.Type = extRef.WithType(nullableType);
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration parameter to GraphQL setup, allowing fields to be nullable for missing values (enabled by default). This provides more flexibility in schema generation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->