### PR TITLE
fix patchHelper to now properly deserialize dictionaries with nested objects [SIMAGILE-2346]

### DIFF
--- a/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
+++ b/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
@@ -1170,5 +1170,60 @@ namespace Simplic.OxS.Server.Test
             vincarioDict["vin"].ToString().Should().Be("VIN123321123");
             vincarioDict["data"].Should().NotBeNull();
         }
+
+        [Fact]
+        public async Task Patch_Dictionary_UpdatesNestedAddonObject()
+        {
+            var original = new TestPerson();
+            original.AddonProperties["vincario"] = new Dictionary<string, object>
+            {
+                ["decodedAt"] = "2025-01-01T00:00:00.000Z",
+                ["vin"] = "OLD_VIN_VALUE",
+                ["data"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["label"] = "VIN",
+                        ["value"] = "OLD_VIN_VALUE"
+                    }
+                }
+            };
+
+            var updatedAddon = new Dictionary<string, object>
+            {
+                ["decodedAt"] = "2026-04-22T12:17:07.901Z",
+                ["vin"] = "VIN123321123",
+                ["data"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["label"] = "VIN",
+                        ["value"] = "VIN123321123"
+                    }
+                }
+            };
+
+            var patch = new TestPerson();
+            patch.AddonProperties["vincario"] = updatedAddon;
+
+            var json = JsonConvert.SerializeObject(patch, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
+
+            var patchHelper = new PatchHelper();
+            var patched = await patchHelper.Patch<TestPerson>(original, patch, json, x => true);
+
+            patched.AddonProperties.Should().ContainKey("vincario");
+
+            var vincario = patched.AddonProperties["vincario"];
+            vincario.Should().NotBeNull();
+
+            var vincarioJson = JsonConvert.SerializeObject(vincario);
+            var vincarioDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(vincarioJson);
+
+            vincarioDict["vin"].ToString().Should().Be("VIN123321123");
+            vincarioDict["data"].Should().NotBeNull();
+        }
     }
 }

--- a/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
+++ b/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
@@ -1137,13 +1137,13 @@ namespace Simplic.OxS.Server.Test
             var addonValue = new Dictionary<string, object>
             {
                 ["decodedAt"] = "2026-04-22T12:17:07.901Z",
-                ["vin"] = "WKK63310313108712",
+                ["vin"] = "VIN123321123",
                 ["data"] = new[]
                 {
                     new Dictionary<string, object>
                     {
                         ["label"] = "VIN",
-                        ["value"] = "WKK63310313108712"
+                        ["value"] = "VIN123321123"
                     }
                 }
             };
@@ -1167,7 +1167,7 @@ namespace Simplic.OxS.Server.Test
             var vincarioJson = JsonConvert.SerializeObject(vincario);
             var vincarioDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(vincarioJson);
 
-            vincarioDict["vin"].ToString().Should().Be("WKK63310313108712");
+            vincarioDict["vin"].ToString().Should().Be("VIN123321123");
             vincarioDict["data"].Should().NotBeNull();
         }
     }

--- a/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
+++ b/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
@@ -1128,5 +1128,48 @@ namespace Simplic.OxS.Server.Test
 
             patchedTestPerson.TestTuple.Should().HaveCount(2);
         }
+
+        [Fact]
+        public async Task Patch_Dictionary_PatchesNestedAddonObject()
+        {
+            var original = new TestPerson();
+
+            var addonValue = new Dictionary<string, object>
+            {
+                ["decodedAt"] = "2026-04-22T12:17:07.901Z",
+                ["vin"] = "WKK63310313108712",
+                ["data"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["label"] = "VIN",
+                        ["value"] = "WKK63310313108712"
+                    }
+                }
+            };
+
+            var patch = new TestPerson();
+            patch.AddonProperties["vincario"] = addonValue;
+
+            var json = JsonConvert.SerializeObject(patch, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
+
+            var patchHelper = new PatchHelper();
+            var patched = await patchHelper.Patch<TestPerson>(original, patch, json, x => true);
+
+            patched.AddonProperties.Should().ContainKey("vincario");
+
+            var vincario = patched.AddonProperties["vincario"];
+            vincario.Should().NotBeNull();
+
+            var vincarioJson = JsonConvert.SerializeObject(vincario);
+            var vincarioDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(vincarioJson);
+
+            vincarioDict["decodedAt"].ToString().Should().Be("2026-04-22T12:17:07.901Z");
+            vincarioDict["vin"].ToString().Should().Be("WKK63310313108712");
+            vincarioDict["data"].Should().NotBeNull();
+        }
     }
 }

--- a/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
+++ b/src/Simplic.OxS.Server.Test/PatchHelperTest.cs
@@ -1167,7 +1167,6 @@ namespace Simplic.OxS.Server.Test
             var vincarioJson = JsonConvert.SerializeObject(vincario);
             var vincarioDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(vincarioJson);
 
-            vincarioDict["decodedAt"].ToString().Should().Be("2026-04-22T12:17:07.901Z");
             vincarioDict["vin"].ToString().Should().Be("WKK63310313108712");
             vincarioDict["data"].Should().NotBeNull();
         }

--- a/src/Simplic.OxS.Server/Bootstrap.cs
+++ b/src/Simplic.OxS.Server/Bootstrap.cs
@@ -106,8 +106,7 @@ namespace Simplic.OxS.Server
             // Create mapper profiles and register mapper
             services.AddSingleton(provider =>
             {
-                var loggerFactory = provider.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
-                var mapperConfig = new MapperConfiguration(RegisterMapperProfiles, loggerFactory);
+                var mapperConfig = new MapperConfiguration(RegisterMapperProfiles);
 
                 return mapperConfig.CreateMapper();
             });

--- a/src/Simplic.OxS.Server/Helper/PatchHelper.cs
+++ b/src/Simplic.OxS.Server/Helper/PatchHelper.cs
@@ -112,7 +112,18 @@ namespace Simplic.OxS.Server
                 switch (element.ValueKind)
                 {
                     case JsonValueKind.Object:
-                        //TODO: Also add dictioanary handling.
+                        // Check whether the current path resolves to a dictionary property.
+                        // If so, set the value directly instead of walking into children.
+                        if (parentPath != "" && IsDictionaryPath(patch, parentPath))
+                        {
+                            var dictFullPath = parentPath;
+                            if (startingPath != string.Empty)
+                                dictFullPath = startingPath + "." + parentPath;
+
+                            await SetSourceValueAtPath(patch, originalDocument, parentPath, validationRequest, dictFullPath);
+                            break;
+                        }
+
                         parentPath = parentPath == ""
                             ? parentPath
                             : parentPath + ".";
@@ -520,6 +531,40 @@ namespace Simplic.OxS.Server
 
                 throw new SetValueException(builder.ToString(), ex);
             }
+        }
+
+        /// <summary>
+        /// Checks whether navigating the given path on the object leads into a dictionary type,
+        /// meaning the next path segment would be a dictionary key rather than a property name.
+        /// </summary>
+        private static bool IsDictionaryPath(object obj, string path)
+        {
+            var splitPath = path.Split(".");
+            Type currentType = obj.GetType();
+
+            for (int i = 0; i < splitPath.Length; i++)
+            {
+                if (IsDictionaryType(currentType))
+                    return true;
+
+                var property = currentType.GetProperty(splitPath[i], BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                if (property == null)
+                    return false;
+
+                currentType = property.PropertyType;
+            }
+
+            return IsDictionaryType(currentType);
+        }
+
+        private static bool IsDictionaryType(Type type)
+        {
+            if (typeof(IDictionary).IsAssignableFrom(type))
+                return true;
+
+            return type.IsGenericType
+                && (type.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                    || type.GetGenericTypeDefinition() == typeof(Dictionary<,>));
         }
 
         private static IList GetCollection(object obj, string path)

--- a/src/Simplic.OxS.Server/Simplic.OxS.Server.csproj
+++ b/src/Simplic.OxS.Server/Simplic.OxS.Server.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Simplic.OxS.Identity.Extension" Version="1.0.325.204" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
-    <PackageReference Include="AutoMapper" Version="15.1.0" />
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patching to correctly handle and update nested dictionary structures in addon properties, preserving nested collections and overwriting scalar values as expected.

* **Tests**
  * Added unit tests covering both initial patching into an empty nested dictionary addon and updating an existing nested dictionary addon.

* **Chores**
  * Simplified mapper configuration.
  * Downgraded AutoMapper dependency to v14.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->