### PR TITLE
Revert "explicitly set open api version"

### DIFF
--- a/src/Simplic.OxS.Server/Bootstrap.cs
+++ b/src/Simplic.OxS.Server/Bootstrap.cs
@@ -172,7 +172,6 @@ namespace Simplic.OxS.Server
 
             app.UseSwagger(c =>
             {
-                c.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
                 c.PreSerializeFilters.Add((swagger, httpReq) =>
                 {
                     if (env.IsDevelopment())


### PR DESCRIPTION
This reverts commit 34b0ebac7dc425e7a88ed28d3d9b1f1756633f82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified API documentation configuration by removing an explicit version specification, allowing the middleware to use its default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->