### PR TITLE
Change route

### DIFF
--- a/src/Simplic.OxS.Server/Bootstrap.cs
+++ b/src/Simplic.OxS.Server/Bootstrap.cs
@@ -171,7 +171,7 @@ namespace Simplic.OxS.Server
             Console.WriteLine("Add OxQL ASP.NET Core");
             services.AddOxQLAspNetCore<BsonDocument>(options =>
             {
-                options.RoutePrefix = $"{ServiceName}-api/{ApiVersion}/oxql";
+                options.RoutePrefix = "oxql";
                 options.IncludeErrorDetails = true; // CurrentEnvironment.IsDevelopment();
 
                 options.RequireAuthorization = true;
@@ -185,11 +185,11 @@ namespace Simplic.OxS.Server
             Console.WriteLine("Add OxQL Studio");
             services.AddOxQLStudio(options =>
             {
-                options.RoutePath = $"/{ServiceName}-api/{ApiVersion}/oxql";
-                options.ApiBasePath = $"/{ServiceName}-api/{ApiVersion}/oxql";   // matches the OxQLController route
+                options.RoutePath = "/oxql";
+                options.ApiBasePath = $"/{ServiceName}-api/{ApiVersion}/oxql";   // full browser-visible path (includes path base)
                 options.Title = "OxQL Studio";
             });
-
+/vehicle-api/v2/oxql
             // Register web-api controller. Must be executed before creating swagger configuration
             MvcBuilder(services.AddControllers(o =>
             {

--- a/src/Simplic.OxS.Server/Bootstrap.cs
+++ b/src/Simplic.OxS.Server/Bootstrap.cs
@@ -189,7 +189,7 @@ namespace Simplic.OxS.Server
                 options.ApiBasePath = $"/{ServiceName}-api/{ApiVersion}/oxql";   // full browser-visible path (includes path base)
                 options.Title = "OxQL Studio";
             });
-/vehicle-api/v2/oxql
+
             // Register web-api controller. Must be executed before creating swagger configuration
             MvcBuilder(services.AddControllers(o =>
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the OxQL browser and API routes to use a consistent `/oxql` path.
  * Updated the studio link behavior so it matches the new route format and includes the correct full visible path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->